### PR TITLE
[Fixed] Incorrect work for source

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class WriteGood(Linter):
 
     """Provides an interface to write-good."""
 
-    syntax = '*'
+    syntax = ('markdown', 'plain text')
     cmd = ('write-good')
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
See **#6** issue.

I don't find in [**SublimeLinter documentation**](http://www.sublimelinter.com/en/latest/linter_attributes.html#selectors), how we can use `write-good` for comments in all programming languages. Perhaps, it not possible at the time.

About my pull request.

**+**

I think, best use `write-good` for text, not for source, because users get a large number of false positives in source.

**-**

`write-good` don't work in source comments. But I think that the error in code comments are not critical, they are less important than errors in the text.


Thanks.