### PR TITLE
Don't specify python version on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-python:
-  - "3.3"
 # command to install dependencies
 install:
   - pip install flake8


### PR DESCRIPTION
The previously specified version is no longer supported. Instead, let Travis pick a sane default (currently 3.6).